### PR TITLE
Move builders to data classes

### DIFF
--- a/kmp-library/src/commonMain/kotlin/com/novoda/aws/v4/signer/Signer.kt
+++ b/kmp-library/src/commonMain/kotlin/com/novoda/aws/v4/signer/Signer.kt
@@ -6,7 +6,6 @@ import com.novoda.aws.v4.signer.hash.Hmac256Encoder
 import com.novoda.aws.v4.signer.hash.Sha256Encoder
 import com.novoda.aws.v4.signer.hash.toHexString
 import com.novoda.aws.v4.signer.hash.toUtf8ByteArray
-import kotlin.jvm.JvmStatic
 
 class Signer private constructor(
         private val request: CanonicalRequest,
@@ -14,74 +13,85 @@ class Signer private constructor(
         private val date: String,
         private val scope: CredentialScope) {
 
+    companion object {
+        private const val AUTH_TAG = "AWS4"
+        private const val ALGORITHM = "$AUTH_TAG-HMAC-SHA256"
+        private const val X_AMZ_DATE = "X-Amz-Date"
+    }
+
     val canonicalRequest: String
         get() = request.get()
 
     val stringToSign: String
         get() {
             val hashedCanonicalRequest = Sha256Encoder.encode(canonicalRequest)
-            return buildStringToSign(date, scope.get(), hashedCanonicalRequest)
+            return ALGORITHM + "\n" + date + "\n" + scope.get() + "\n" + hashedCanonicalRequest
         }
 
     @ExperimentalUnsignedTypes
     val signature: String
         get() {
             val signature = buildSignature(awsCredentials.secretKey, scope, stringToSign)
-            return buildAuthHeader(awsCredentials.accessKey, scope.get(), request.headers.names, signature)
+            return "$ALGORITHM Credential=${awsCredentials.accessKey}/${scope.get()}, SignedHeaders=${request.headers.names}, Signature=$signature"
         }
 
-    class Builder {
+    @ExperimentalUnsignedTypes
+    private fun buildSignature(secretKey: String, scope: CredentialScope, stringToSign: String): String {
+        val kSecret = (AUTH_TAG + secretKey).toUtf8ByteArray()
+        val kDate = Hmac256Encoder.encode(kSecret, scope.dateWithoutTimestamp)
+        val kRegion = Hmac256Encoder.encode(kDate, scope.region)
+        val kService = Hmac256Encoder.encode(kRegion, scope.service)
+        val kSigning = Hmac256Encoder.encode(kService, CredentialScope.TERMINATION_STRING)
+        return Hmac256Encoder.encode(kSigning, stringToSign).toHexString()
+    }
 
-        private var awsCredentials: AwsCredentials? = null
-        private var region = DEFAULT_REGION
-        private val headersList = ArrayList<Header>()
+    data class Builder(
+            private var awsCredentials: AwsCredentials? = null,
+            private var region: String = DEFAULT_REGION,
+            private val headersList: ArrayList<Header> = arrayListOf()) {
 
-        private val canonicalHeaders: CanonicalHeaders
-            get() {
-                val builder = CanonicalHeaders.Builder()
-                for ((name, value) in headersList) {
-                    builder.add(name, value)
-                }
-                return builder.build()
-            }
-
-        fun awsCredentials(awsCredentials: AwsCredentials): Builder {
-            this.awsCredentials = awsCredentials
-            return this
+        companion object {
+            private const val DEFAULT_REGION = "us-east-1"
+            private const val S3 = "s3"
+            private const val GLACIER = "glacier"
         }
 
-        fun region(region: String): Builder {
-            this.region = region
-            return this
-        }
-
-        fun header(name: String, value: String): Builder {
-            headersList.add(Header(name, value))
-            return this
-        }
-
-        fun header(header: Header): Builder {
-            headersList.add(header)
-            return this
-        }
-
-        fun headers(vararg headers: Header): Builder {
-            headersList.addAll(listOf(*headers))
-            return this
-        }
+        fun awsCredentials(awsCredentials: AwsCredentials) = apply { this.awsCredentials = awsCredentials }
+        fun region(region: String) = apply { this.region = region }
+        fun header(name: String, value: String) = apply { headersList.add(Header(name, value)) }
+        fun header(header: Header) = apply { headersList.add(header) }
+        fun headers(vararg headers: Header) = apply { headersList.addAll(listOf(*headers)) }
 
         fun build(request: HttpRequest, service: String, contentSha256: String): Signer {
-            val canonicalHeaders = canonicalHeaders
-            val date = getDate(canonicalHeaders)
+            val canonicalHeaders = canonicalHeaders()
+            val date = date(canonicalHeaders)
             val dateWithoutTimestamp = formatDateWithoutTimestamp(date)
-            val awsCredentials = getAwsCredentials()
+            val awsCredentials = awsCredentials()
             val canonicalRequest = CanonicalRequest(service, request, canonicalHeaders, contentSha256)
             val scope = CredentialScope(dateWithoutTimestamp, service, region)
             return Signer(canonicalRequest, awsCredentials, date, scope)
         }
 
-        private fun getDate(canonicalHeaders: CanonicalHeaders): String {
+        private fun canonicalHeaders(): CanonicalHeaders {
+            val builder = CanonicalHeaders.Builder()
+            for ((name, value) in headersList) {
+                builder.add(name, value)
+            }
+            return builder.build()
+        }
+
+        private fun date(canonicalHeaders: CanonicalHeaders): String {
             return canonicalHeaders.getFirstValue(X_AMZ_DATE) ?: error("headers missing '$X_AMZ_DATE' header")
+        }
+
+        private fun formatDateWithoutTimestamp(date: String): String {
+            return date.substring(0, 8)
+        }
+
+        private fun awsCredentials(): AwsCredentials {
+            val localAwsCredential = awsCredentials
+            checkNotNull(localAwsCredential, { "Missing required aws credentials" })
+            return localAwsCredential
         }
 
         fun buildS3(request: HttpRequest, contentSha256: String): Signer {
@@ -90,58 +100,6 @@ class Signer private constructor(
 
         fun buildGlacier(request: HttpRequest, contentSha256: String): Signer {
             return build(request, GLACIER, contentSha256)
-        }
-
-        private fun getAwsCredentials(): AwsCredentials {
-            val localAwsCredential = awsCredentials
-            checkNotNull(localAwsCredential, { "Missing required aws credentials" })
-            return localAwsCredential
-        }
-
-        companion object {
-
-            private const val DEFAULT_REGION = "us-east-1"
-            private const val S3 = "s3"
-            private const val GLACIER = "glacier"
-        }
-
-    }
-
-    companion object {
-
-        private const val AUTH_TAG = "AWS4"
-        private const val ALGORITHM = "$AUTH_TAG-HMAC-SHA256"
-        private const val X_AMZ_DATE = "X-Amz-Date"
-
-        @JvmStatic
-        fun builder(): Builder {
-            return Builder()
-        }
-
-        private fun formatDateWithoutTimestamp(date: String): String {
-            return date.substring(0, 8)
-        }
-
-        private fun buildStringToSign(date: String, credentialScope: String, hashedCanonicalRequest: String): String {
-            return ALGORITHM + "\n" + date + "\n" + credentialScope + "\n" + hashedCanonicalRequest
-        }
-
-        private fun buildAuthHeader(accessKey: String, credentialScope: String, signedHeaders: String, signature: String): String {
-            return "$ALGORITHM Credential=$accessKey/$credentialScope, SignedHeaders=$signedHeaders, Signature=$signature"
-        }
-
-        private fun hmacSha256(key: ByteArray, value: String): ByteArray {
-            return Hmac256Encoder.encode(key, value)
-        }
-
-        @ExperimentalUnsignedTypes
-        private fun buildSignature(secretKey: String, scope: CredentialScope, stringToSign: String): String {
-            val kSecret = (AUTH_TAG + secretKey).toUtf8ByteArray()
-            val kDate = hmacSha256(kSecret, scope.dateWithoutTimestamp)
-            val kRegion = hmacSha256(kDate, scope.region)
-            val kService = hmacSha256(kRegion, scope.service)
-            val kSigning = hmacSha256(kService, CredentialScope.TERMINATION_STRING)
-            return hmacSha256(kSigning, stringToSign).toHexString()
         }
     }
 }

--- a/kmp-library/src/commonTest/kotlin/com/novoda/aws/v4/signer/SignerTest.kt
+++ b/kmp-library/src/commonTest/kotlin/com/novoda/aws/v4/signer/SignerTest.kt
@@ -28,7 +28,7 @@ class SignerTest {
         val hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         val request = HttpRequest.create("PUT", "/-/vaults/examplevault")
 
-        val signature = Signer.builder()
+        val signature = Signer.Builder()
                 .awsCredentials(AwsCredentials(ACCESS_KEY, SECRET_KEY))
                 .header("Host", "glacier.us-east-1.amazonaws.com")
                 .header("x-amz-date", "20120525T002453Z")
@@ -46,7 +46,7 @@ class SignerTest {
         val hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         val request = HttpRequest.create("GET", "?max-keys=2&prefix=J")
 
-        val signature = Signer.builder()
+        val signature = Signer.Builder()
                 .awsCredentials(AwsCredentials(ACCESS_KEY, SECRET_KEY))
                 .header("Host", "examplebucket.s3.amazonaws.com")
                 .header("x-amz-date", "20130524T000000Z")
@@ -66,7 +66,7 @@ class SignerTest {
         val treeHash = "05c734c3f16b23358bb49c959d1420edac9f28ee844bf9b0580754c0f540acd8"
         val request = HttpRequest.create("PUT", "/-/vaults/dev2/multipart-uploads/j3eqysOZoNF3UiEoN3k_b6bdRGGdzgEfsLoUyZhMIwKRMuDLEYRw2nlCh8QXQ_dzqQMxrgFtmZjatxbFIZ9HpnIUi93B")
 
-        val signature = Signer.builder()
+        val signature = Signer.Builder()
                 .awsCredentials(AwsCredentials(ACCESS_KEY, SECRET_KEY))
                 .header("Accept", "application/json")
                 .header("Content-Length", "1049350")

--- a/kmp-library/src/jvmTest/kotlin/AWSTestSuite.kt
+++ b/kmp-library/src/jvmTest/kotlin/AWSTestSuite.kt
@@ -29,7 +29,7 @@ class AWSTestSuite(private val testData: TestData) {
 
         val request = testData.request
 
-        val builder = Signer.builder().awsCredentials(AwsCredentials(ACCESS_KEY, SECRET_KEY))
+        val builder = Signer.Builder().awsCredentials(AwsCredentials(ACCESS_KEY, SECRET_KEY))
                 .region(REGION)
         for (header in testData.request.headers) {
             builder.header(header)


### PR DESCRIPTION
The current class keeps the Java Builder pattern.

This PR moves the Builders to be data classes making the code more concise