### PR TITLE
Issue 16: Prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Compatible with Java 7+, Kotlin & Swift.
 
 [![CI status](https://ci.novoda.com/buildStatus/icon?job=aws-v4-signer)](https://ci.novoda.com/job/aws-v4-signer/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/aws-v4-signer-java/images/download.svg)](https://bintray.com/novoda/snapshots/aws-v4-signer-java/_latestVersion)
 
+### Gradle
+
 Add the latest aws-v4-signer Gradle dependency to your project
 
 ```gradle
@@ -20,6 +22,15 @@ repository {
 dependencies {
     implementation 'com.novoda:aws-v4-signer:0.0.1'
 }
+```
+
+### Xcode
+
+Generate an Xcode framework and link it to your project following the [official documentation](https://kotlinlang.org/docs/tutorials/native/mpp-ios-android.html).
+An example can be found under `/samples/ios`. 
+
+```gradle
+./gradlew :aws-v4-signer:packForXCode
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aws-v4-signer
 
-aws-v4-signer is a lightweight Kotlin-Multiplatform implementation of the AWS V4 signing algorithm required by many of the AWS services. 
+aws-v4-signer is a lightweight Kotlin-Multiplatform implementation of the [AWS V4 signing algorithm](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) required by many of the AWS services. 
 
 Compatible with Java 7+, Kotlin & Swift.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compatible with Java 7+, Kotlin & Swift.
 
 ## Setup
 
-[![CI status](https://ci.novoda.com/buildStatus/icon?job=aws-v4-signer)](https://ci.novoda.com/job/aws-v4-signer/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/aws-v4-signer-java/images/download.svg)](https://bintray.com/novoda/snapshots/aws-v4-signer-java/_latestVersion)
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=aws-v4-signer)](https://ci.novoda.com/job/aws-v4-signer/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda-oss/maven/aws-v4-signer/images/download.svg)](https://bintray.com/novoda-oss/maven/aws-v4-signer/_latestVersion)
 
 ### Gradle
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compatible with Java 7+, Kotlin & Swift.
 
 ## Setup
 
-[![CI status](https://ci.novoda.com/buildStatus/icon?job=aws-v4-signer-java)](https://ci.novoda.com/job/aws-v4-signer-java/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/aws-v4-signer-java/images/download.svg)](https://bintray.com/novoda/snapshots/aws-v4-signer-java/_latestVersion)
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=aws-v4-signer)](https://ci.novoda.com/job/aws-v4-signer/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/aws-v4-signer-java/images/download.svg)](https://bintray.com/novoda/snapshots/aws-v4-signer-java/_latestVersion)
 
 Add the latest aws-v4-signer Gradle dependency to your project
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4-jetbrains-3"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4-jetbrains-3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,12 @@ buildscript {
     ext.ktor_version = '1.1.2'
     repositories {
         jcenter()
+        maven { url 'https://dl.bintray.com/jetbrains/kotlin-native-dependencies' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
-        classpath 'com.novoda:bintray-release:0.9'
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4-jetbrains-3"
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -32,15 +32,6 @@ def pomConfig = {
             distribution "repo"
         }
     }
-    developers {
-        developer {
-            id "novoda"
-            name "Novoda GmbH"
-        }
-    }
-    scm {
-        url "https://github.com/novoda/aws-v4-signer-java"
-    }
 }
 
 bintray {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -52,15 +52,13 @@ bintray {
     }
 }
 
-afterEvaluate {
-    project.publishing.publications.forEach { publication ->
-        publication.pom.withXml {
-            def root = asNode()
-            root.appendNode('name', project.name)
-            root.appendNode('description', 'A Kotlin-Multiplatform implementation of the AWS V4 signing algorithm for Android and iOS')
-            root.appendNode('url', 'https://github.com/novoda/aws-v4-signer-java')
-            root.children().last() + pomConfig
-        }
+project.publishing.publications.all { publication ->
+    publication.pom.withXml {
+        def root = asNode()
+        root.appendNode('name', project.name)
+        root.appendNode('description', 'A Kotlin-Multiplatform implementation of the AWS V4 signing algorithm for Android and iOS')
+        root.appendNode('url', 'https://github.com/novoda/aws-v4-signer-java')
+        root.children().last() + pomConfig
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,78 @@
+apply plugin: 'com.novoda.build-properties'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
+buildProperties {
+    cli {
+        using(project)
+    }
+
+    bintray {
+        def bintrayCredentials = {
+            return isDryRun() ?
+                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
+        }
+        using(bintrayCredentials()).or(cli)
+        description = '''This should contain the following properties:
+                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                        - bintrayUser: name of the account used to deploy the artifacts
+                        - bintrayKey: API key of the account used to deploy the artifacts'''
+                .stripIndent()
+    }
+}
+
+
+def pomConfig = {
+    licenses {
+        license {
+            name "The Apache Software License, Version 2.0"
+            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "novoda"
+            name "Novoda GmbH"
+        }
+    }
+    scm {
+        url "https://github.com/novoda/aws-v4-signer-java"
+    }
+}
+
+bintray {
+
+    user = project.buildProperties.bintray['bintrayUser'].string
+    key = project.buildProperties.bintray['bintrayKey'].string
+
+    pkg {
+        userOrg = project.buildProperties.bintray['bintrayOrg'].string
+        repo = project.buildProperties.bintray['bintrayRepo'].string
+        name = "aws-v4-signer"
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/novoda/aws-v4-signer-java'
+    }
+}
+
+afterEvaluate {
+    project.publishing.publications.forEach { publication ->
+        publication.pom.withXml {
+            def root = asNode()
+            root.appendNode('name', project.name)
+            root.appendNode('description', 'A Kotlin-Multiplatform implementation of the AWS V4 signing algorithm for Android and iOS')
+            root.appendNode('url', 'https://github.com/novoda/aws-v4-signer-java')
+            root.children().last() + pomConfig
+        }
+    }
+}
+
+bintrayUpload.doFirst {
+    publications = project.publishing.publications
+}
+
+boolean isDryRun() {
+    buildProperties.cli['dryRun'].or(true).boolean
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -23,6 +23,9 @@ buildProperties {
     }
 }
 
+boolean isDryRun() {
+    buildProperties.cli['dryRun'].or(true).boolean
+}
 
 def pomConfig = {
     licenses {
@@ -38,7 +41,8 @@ bintray {
 
     user = project.buildProperties.bintray['bintrayUser'].string
     key = project.buildProperties.bintray['bintrayKey'].string
-
+    dryRun = project.buildProperties.cli['dryRun'].or(true).boolean
+    
     pkg {
         userOrg = project.buildProperties.bintray['bintrayOrg'].string
         repo = project.buildProperties.bintray['bintrayRepo'].string
@@ -64,6 +68,3 @@ bintrayUpload.doFirst {
     publications = project.publishing.publications
 }
 
-boolean isDryRun() {
-    buildProperties.cli['dryRun'].or(true).boolean
-}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,27 +11,30 @@ buildProperties {
     bintray {
         def bintrayCredentials = {
             return isDryRun() ?
-                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
                     new File("${System.getenv('BINTRAY_PROPERTIES')}")
         }
         using(bintrayCredentials()).or(cli)
         description = '''This should contain the following properties:
-                         - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
-                         - bintrayUser: name of the account used to deploy the artifacts
-                         - bintrayKey: API key of the account used to deploy the artifacts'''.stripIndent()
+                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                        - bintrayUser: name of the account used to deploy the artifacts
+                        - bintrayKey: API key of the account used to deploy the artifacts'''
+                .stripIndent()
     }
 }
 
+group 'com.novoda'
 version = '0.0.1'
 
 publish {
-    userOrg = 'novoda'
-    groupId = 'com.novoda'
+    groupId = group
     artifactId = 'aws-v4-signer'
     publishVersion = project.version
     website = 'https://github.com/novoda/aws-v4-signer-java'
     desc = 'Kotlin Multiplatform AWS V4 Signer'
 
+    userOrg = project.buildProperties.bintray['bintrayOrg'].string
     repoName = project.buildProperties.bintray['bintrayRepo'].string
     bintrayUser = project.buildProperties.bintray['bintrayUser'].string
     bintrayKey = project.buildProperties.bintray['bintrayKey'].string

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,41 @@
 apply plugin: 'kotlin-multiplatform'
-group 'com.novoda'
-version '0.0.1'
+apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.novoda.build-properties'
 
-apply plugin: 'maven-publish'
+
+buildProperties {
+    cli {
+        using(project)
+    }
+
+    bintray {
+        def bintrayCredentials = {
+            return isDryRun() ?
+                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
+        }
+        using(bintrayCredentials()).or(cli)
+        description = '''This should contain the following properties:
+                         - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                         - bintrayUser: name of the account used to deploy the artifacts
+                         - bintrayKey: API key of the account used to deploy the artifacts'''.stripIndent()
+    }
+}
+
+version = '0.0.1'
+
+publish {
+    userOrg = 'novoda'
+    groupId = 'com.novoda'
+    artifactId = 'aws-v4-signer'
+    publishVersion = project.version
+    website = 'https://github.com/novoda/aws-v4-signer-java'
+    desc = 'Kotlin Multiplatform AWS V4 Signer'
+
+    repoName = project.buildProperties.bintray['bintrayRepo'].string
+    bintrayUser = project.buildProperties.bintray['bintrayUser'].string
+    bintrayKey = project.buildProperties.bintray['bintrayKey'].string
+}
 
 kotlin {
     targets {
@@ -72,4 +105,8 @@ kotlin {
 
 configurations {
     compileClasspath
+}
+
+boolean isDryRun() {
+    buildProperties.cli['dryRun'].or(true).boolean
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,44 +1,8 @@
 apply plugin: 'kotlin-multiplatform'
-apply plugin: 'com.novoda.bintray-release'
-apply plugin: 'com.novoda.build-properties'
-
-
-buildProperties {
-    cli {
-        using(project)
-    }
-
-    bintray {
-        def bintrayCredentials = {
-            return isDryRun() ?
-                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
-                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
-        }
-        using(bintrayCredentials()).or(cli)
-        description = '''This should contain the following properties:
-                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
-                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
-                        - bintrayUser: name of the account used to deploy the artifacts
-                        - bintrayKey: API key of the account used to deploy the artifacts'''
-                .stripIndent()
-    }
-}
+apply from: rootProject.file('gradle/publish.gradle')
 
 group 'com.novoda'
 version = '0.0.1'
-
-publish {
-    groupId = group
-    artifactId = 'aws-v4-signer'
-    publishVersion = project.version
-    website = 'https://github.com/novoda/aws-v4-signer-java'
-    desc = 'Kotlin Multiplatform AWS V4 Signer'
-
-    userOrg = project.buildProperties.bintray['bintrayOrg'].string
-    repoName = project.buildProperties.bintray['bintrayRepo'].string
-    bintrayUser = project.buildProperties.bintray['bintrayUser'].string
-    bintrayKey = project.buildProperties.bintray['bintrayKey'].string
-}
 
 kotlin {
     targets {
@@ -108,8 +72,4 @@ kotlin {
 
 configurations {
     compileClasspath
-}
-
-boolean isDryRun() {
-    buildProperties.cli['dryRun'].or(true).boolean
 }


### PR DESCRIPTION
Tracked by https://github.com/novoda/aws-v4-signer-java/issues/16

### Description
This prepares the bintray release of the library.

### Considerations
- add setup instructions for `Xcode`
- configure jfrog bintray  plugin by mirroring the configuration of
the [multi-settings library](https://github.com/russhwolf/multiplatform-settings)
- modify jenkins link from `aws-v4-signer-java` to `aws-v4-signer`
- modify bintray links from `https://bintray.com/novoda/snapshots/aws-v4-signer-java` to `https://bintray.com/novoda-oss/maven/aws-v4-signer` 