### PR TITLE
Update packForXCode task to publish ios artefacts

### DIFF
--- a/.github/workflows/pull-request-builder.yml
+++ b/.github/workflows/pull-request-builder.yml
@@ -1,0 +1,27 @@
+name: Pull Request Builder
+
+on:
+  pull_request:
+
+env:
+  GRADLE_USER_HOME: .gradle
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+       path: .gradle/caches
+       key: gradle-cache-${{ hashFiles('**/*.gradle') }}
+       restore-keys: gradle-cache
+    - name: Build
+      run: ./gradlew --no-daemon build check

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,11 @@ kotlin {
         fromPreset(presets.jvm, 'jvm')
         // This preset is for iPhone emulator
         // Switch here to presets.iosArm64 to build library for iPhone device
-        fromPreset(presets.iosX64, 'iOS')
+        fromPreset(presets.iosX64, 'iOS') {
+            binaries.framework {
+                baseName = "SharedCode"
+            }
+        }
     }
     sourceSets {
         commonMain {
@@ -55,10 +59,12 @@ kotlin {
     task packForXCode(type: Sync) {
         final File frameworkDir = new File(buildDir, "xcode-frameworks")
         final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
+        def framework = kotlin.targets.getByName("iOS").binaries.getFramework(mode)
+        dependsOn(framework.linkTask)
 
         inputs.property "mode", mode
 
-        from { kotlin.targets.iOS.compilations.main.getBinary("FRAMEWORK", mode).parentFile }
+        from { framework.outputDirectory }
         into frameworkDir
 
         doLast {


### PR DESCRIPTION
## Problem

Current project setup would fail building iOS binaries and is needed to publish next version to bintray. `./gradlew :aws-v4-signer:packForXCode` would fail.

## Solution

Update iOS binaries generation according to updated kotlin multiplatform project configuration: https://play.kotlinlang.org/hands-on/Targeting%20iOS%20and%20Android%20with%20Kotlin%20Multiplatform/03_CreatingSharedCode